### PR TITLE
Fix uses of Mock.assert_called_once in unit tests (fixes OPS-2077)

### DIFF
--- a/django_short_urls/tests/main.py
+++ b/django_short_urls/tests/main.py
@@ -25,7 +25,7 @@ class ViewMainTestCase(MongoTestCase):
             302
         )
         self.assertEqual(self.link.reload().clicks, 1)
-        mock_statsd.increment.assertCalledOnce()
+        mock_statsd.increment.assert_called_once()
 
     def test_redirect_suffix(self):
         response = main(self.factory.get('/%s/recruiter' % self.path), self.path + '/recruiter')

--- a/django_short_urls/tests/models/link.py
+++ b/django_short_urls/tests/models/link.py
@@ -49,9 +49,9 @@ class LinkTestCase(MongoTestCase):
         # statsd.histogram should only be created at creation
         with patch('django_short_urls.models.statsd') as mock_statsd:
             link1 = Link.shorten(**kwargs)
-            mock_statsd.histogram.assertCalledOnce()
+            mock_statsd.histogram.assert_called_once()
             link2 = Link.shorten(**kwargs)
-            mock_statsd.histogram.assertCalledOnce()
+            mock_statsd.histogram.assert_called_once()
 
         self.assertEqual(link1.hash, link2.hash)
 


### PR DESCRIPTION
```
make lint test
```
